### PR TITLE
更改头像链接

### DIFF
--- a/inc/Utils.php
+++ b/inc/Utils.php
@@ -134,7 +134,7 @@ function setPostViews( $postID ) {
 function gravatar_cn( $url ) {
 	$gravatar_url = array( '0.gravatar.com', '1.gravatar.com', '2.gravatar.com', 'secure.gravatar.com' );
 
-	return str_replace( $gravatar_url, 'dn-qiniu-avatar.qbox.me', $url );
+	return str_replace( $gravatar_url, 'sdn.geekzu.org', $url );
 }
 
 add_filter( 'get_avatar_url', 'gravatar_cn', 4 );


### PR DESCRIPTION
修复七牛头像缓存导致的头像错误显示为默认头像的问题